### PR TITLE
fix : fixed issue with json body handling in test_create_answer function

### DIFF
--- a/test/test.py
+++ b/test/test.py
@@ -39,7 +39,7 @@ def test_create_answer():
     body = {"user_id": 1, "answers": [{"question_id": 1, "alternative_id": 2}, {
         "question_id": 2, "alternative_id": 2}, {"question_id": 2, "alternative_id": 2}]}
     body = json.dumps(body)
-    response = client.post('/answer', data=body)
+    response = client.post('/answer', json=body)
     assert response.status_code == 201
 
 


### PR DESCRIPTION
Pull request for Issue #15 
Issue Description : 
The test_create_answer function is incorrectly using the data parameter to send JSON data. The data parameter is meant for form-encoded data, while JSON data should be sent using the json parameter in FastAPI/Starlette TestClient.
Steps to Reproduce:

Run the test_create_answer function.
Observe that the test fails due to incorrect JSON handling or doesn't work as intended.
Expected Behavior:
The test should post the JSON payload correctly to the endpoint using the json parameter.

Actual Behavior:
Using the data parameter causes issues in JSON data encoding or incorrect behavior.

Code Snippet (Problem Area):
def test_create_answer(): body = {"user_id": 1, "answers": [{"question_id": 1, "alternative_id": 2}, { "question_id": 2, "alternative_id": 2}, {"question_id": 2, "alternative_id": 2}]} body = json.dumps(body)  # Unnecessary step response = client.post('/answer', data=body)  # Incorrect usage of 'data' assert response.status_code == 201 

fixed code : 
def test_create_answer():
    body = {"user_id": 1, "answers": [{"question_id": 1, "alternative_id": 2}, {
        "question_id": 2, "alternative_id": 2}, {"question_id": 2, "alternative_id": 2}]}
    body = json.dumps(body)
    response = client.post('/answer', json=body)
    assert response.status_code == 201



